### PR TITLE
feat: Stricter enforcement and specific file exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ plugins:
         - png
         - jpg
         - svg
+      excluded_files:
+        - css/favicon.png
+      strict: true
 ```
 
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
@@ -43,7 +46,7 @@ Search is done as follows:
 4. Once all pages have been processed, display an MkDocs info message listing all non-referenced files:
 
 ```
-WARNING -  The following files exist in the docs directory, but may be unused:
+INFO -  The following files exist in the docs directory, but may be unused:
         - images/image1.svg
         - images/subdir/image2.png
 ```

--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ WARNING -  The following files exist in the docs directory, but may be unused:
 * `dir`: The directory where to search for unused files. Path is relative to `docs_dir`. The plugin recurses all subdirectories. For example, if you specify `images` and `docs_dir` is set to `docs`, the plugin searches in `docs/images`, including all subdirectories. Defaults to `docs_dir`.
 * `file_types`: List of file types the plugin should process (whitelist). If empty or omitted, all files **except Markdown (md)** files will be processed. Defaults to `[]`.
 * `excluded_files`: List of files (relative to the `dir`), which are explicitly excluded. Works in combination with `file_types`
+* `strict`: A boolean, defaulting to `false`, which elevates the log level to warning. This allows unused-files to be combined with `mkdocs` strict flag (`-s`) to abort a build if unused files exist.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ Search is done as follows:
 4. Once all pages have been processed, display an MkDocs info message listing all non-referenced files:
 
 ```
-INFO -  The following files exist in the docs directory, but may be unused:
+WARNING -  The following files exist in the docs directory, but may be unused:
         - images/image1.svg
-        - images/subdir/image2.png 
+        - images/subdir/image2.png
 ```
 
 ## Options
 
 * `dir`: The directory where to search for unused files. Path is relative to `docs_dir`. The plugin recurses all subdirectories. For example, if you specify `images` and `docs_dir` is set to `docs`, the plugin searches in `docs/images`, including all subdirectories. Defaults to `docs_dir`.
 * `file_types`: List of file types the plugin should process (whitelist). If empty or omitted, all files **except Markdown (md)** files will be processed. Defaults to `[]`.
+* `excluded_files`: List of files (relative to the `dir`), which are explicitly excluded. Works in combination with `file_types`

--- a/mkdocs_unused_files/plugin.py
+++ b/mkdocs_unused_files/plugin.py
@@ -14,10 +14,11 @@ class UnusedFilesPlugin(BasePlugin):
     config_scheme = (
         ('dir', config_options.Type(str, default='')),
         ('file_types',config_options.Type((str, list), default=[])),
+        ('excluded_files', config_options.Type((str, list), default=[]))
     )
 
     def matches_type(self, str):
-        types = self.config["file_types"]
+        types = self.config['file_types']
         return not types or (str and str.endswith(tuple(types)))
 
     def rewrite_ref(self, ref, page_uri):
@@ -29,7 +30,7 @@ class UnusedFilesPlugin(BasePlugin):
         return ref
 
     def on_files(self, files, config):
-        dir = os.path.join(config.docs_dir, self.config["dir"])
+        dir = os.path.join(config.docs_dir, self.config['dir'])
         # Get all files in directory
         for path, _, files in os.walk(dir):
             for file in files:
@@ -39,6 +40,8 @@ class UnusedFilesPlugin(BasePlugin):
                     # Create entry from relative path between full path and docs_dir + filename
                     # When path and docs_dir are identical, relpath returns ".". We use normpath() to resolve that
                     entry = os.path.normpath(os.path.join(os.path.relpath(path, config.docs_dir), file))
+                    if file in self.config['excluded_files']:
+                        continue
                     self.file_list.append(entry)
 
     def on_page_content(self, html, page, config, files):
@@ -57,5 +60,5 @@ class UnusedFilesPlugin(BasePlugin):
 
     def on_post_build(self, config):
         if self.file_list:
-            log.info('The following files exist in the docs directory, but may be unused:\n  - {}'.format('\n  - '.join(self.file_list)))
+            log.warning('The following files exist in the docs directory, but may be unused:\n  - {}'.format('\n  - '.join(self.file_list)))
 

--- a/mkdocs_unused_files/plugin.py
+++ b/mkdocs_unused_files/plugin.py
@@ -14,7 +14,8 @@ class UnusedFilesPlugin(BasePlugin):
     config_scheme = (
         ('dir', config_options.Type(str, default='')),
         ('file_types',config_options.Type((str, list), default=[])),
-        ('excluded_files', config_options.Type((str, list), default=[]))
+        ('excluded_files', config_options.Type((str, list), default=[])),
+        ('strict', config_options.Type(bool, default=False))
     )
 
     def matches_type(self, str):
@@ -40,7 +41,7 @@ class UnusedFilesPlugin(BasePlugin):
                     # Create entry from relative path between full path and docs_dir + filename
                     # When path and docs_dir are identical, relpath returns ".". We use normpath() to resolve that
                     entry = os.path.normpath(os.path.join(os.path.relpath(path, config.docs_dir), file))
-                    if file in self.config['excluded_files']:
+                    if entry in self.config['excluded_files']:
                         continue
                     self.file_list.append(entry)
 
@@ -59,6 +60,9 @@ class UnusedFilesPlugin(BasePlugin):
         self.file_list = [i for i in self.file_list if i not in ref_list]
 
     def on_post_build(self, config):
+        logger = log.info
+        if self.config['strict']:
+            logger = log.warning
         if self.file_list:
-            log.warning('The following files exist in the docs directory, but may be unused:\n  - {}'.format('\n  - '.join(self.file_list)))
+            logger('The following files exist in the docs directory, but may be unused:\n  - {}'.format('\n  - '.join(self.file_list)))
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-unused-files',
-    version='0.1.4',
+    version='0.1.5',
     description='An MkDocs plugin to find unused (orphaned) files in your project.',
     long_description='',
     keywords='mkdocs',


### PR DESCRIPTION
This PR introduces two changes - note that it will result in overall behaviour changes and may be a major version bump:

1. Changes the level from INFO to WARNING. This ensures when `mkdocs -s` is used that the process will error out of unused files are found.
2. Introduces an `excluded_files` flag. 

I made a couple of minor formatting changes on the way through as well.

Closes: #3

